### PR TITLE
Adds highscore feature to multiplayer

### DIFF
--- a/src/test/test_db.py
+++ b/src/test/test_db.py
@@ -8,6 +8,7 @@ import uuid
 import datetime
 from pytest import raises
 
+from utilities.difficulties import DifficultyId
 from webapp import api
 from webapp import models
 from utilities.exceptions import UserError
@@ -47,8 +48,10 @@ def test_insert_into_scores():
     """
         Check that records exists in Scores table after inserting.
     """
+    easy_difficulty = DifficultyId.Easy
     with api.app.app_context():
-        result = models.insert_into_scores("Test User", 500, TestValues.TODAY)
+        result = models.insert_into_scores(
+            "Test User", 500, TestValues.TODAY, easy_difficulty)
 
     assert result
 
@@ -94,7 +97,8 @@ def test_illegal_parameter_scores():
         into scores table.
     """
     with raises(UserError):
-        models.insert_into_scores(100, "score", "01.01.2020")
+        models.insert_into_scores(
+            100, "score", "01.01.2020", DifficultyId.Medium)
 
 
 def test_illegal_parameter_labels():

--- a/src/utilities/difficulties.py
+++ b/src/utilities/difficulties.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class DifficultyId(int, Enum):
+    Easy = 1
+    Medium = 2
+    Hard = 3
+    Multiplayer = 4

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -19,6 +19,7 @@ import time
 import random
 
 from customvision.classifier import Classifier
+from utilities.difficulties import DifficultyId
 from webapp import models
 from webapp import storage
 from utilities.exceptions import UserError
@@ -176,7 +177,7 @@ def view_high_score(json_data):
         Read highscore from database. Return top n of all time and daily high
         scores.
     """
-    difficulty_id = 4
+    difficulty_id = DifficultyId.Multiplayer
     data = json.loads(json_data)
     game_id = data["game_id"]
     # read top n overall high score

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -11,10 +11,10 @@ from flask import Flask
 from PIL import Image
 from PIL import ImageChops
 from io import BytesIO
+from datetime import datetime
 import os
 import json
 import uuid
-import datetime
 import time
 import random
 
@@ -121,7 +121,7 @@ def handle_joinGame(json_data):
     else:
         game_id = uuid.uuid4().hex
         labels = models.get_n_labels(setup.NUM_GAMES, difficulty_id)
-        today = datetime.datetime.today()
+        today = datetime.today()
         models.insert_into_games(
             game_id, json.dumps(labels), today, difficulty_id)
         models.insert_into_players(player_id, game_id, "Waiting")
@@ -155,6 +155,42 @@ def handle_getLabel(json_data):
     label = get_label(game_id)
     app.logger.info("returned label: " + json.dumps(label))
     emit("getLabel", json.dumps(label), room=game_id)
+
+
+@socketio.on("postScore")
+def handle_postScore(json_data):
+    data = json.loads(json_data)
+    app.logger.info(data)
+    player_id = data.get("player_id")
+    score = float(data.get("score"))
+    difficulty_id = int(data.get("difficulty_id"))
+    assert isinstance(difficulty_id, int)
+
+    today = datetime.today()
+    models.insert_into_scores(player_id, score, today, difficulty_id)
+
+
+@socketio.on("viewHighScore")
+def view_high_score(json_data):
+    """
+        Read highscore from database. Return top n of all time and daily high
+        scores.
+    """
+    difficulty_id = 4
+    data = json.loads(json_data)
+    game_id = data["game_id"]
+    # read top n overall high score
+    top_n_high_scores = models.get_top_n_high_score_list(
+        setup.TOP_N, difficulty_id=difficulty_id)
+    # read daily high score
+    daily_high_scores = models.get_daily_high_score(
+        difficulty_id=difficulty_id)
+    data = {
+        "daily": daily_high_scores,
+        "total": top_n_high_scores,
+    }
+
+    emit("viewHighScore", json.dumps(data), room=game_id)
 
 
 @socketio.on("classify")
@@ -241,7 +277,6 @@ def handle_endGame(json_data):
         their scores and the player with the highest score is deemed the winner.
         The two scores are finally stored in the database.
     """
-    date = datetime.datetime.today()
     data = json.loads(json_data)
     # Get data from given player
     game_id = data["game_id"]
@@ -251,7 +286,6 @@ def handle_endGame(json_data):
         pass
         # raise excp.BadRequest("Game not finished")
     # Insert score information into db
-    models.insert_into_scores(player_id, score_player, date)
     # Create a list containing player data which is sent out to both players
     return_data = {"score": score_player, "playerId": player_id}
     # Retrieve the opponent (client) to pass on the score to

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -187,8 +187,7 @@ def insert_into_scores(player_id, score, date, difficulty_id: DifficultyId):
     else:
         raise UserError(
             "Name has to be string, score can be int or "
-            "float, difficulty_id has to be an integer and date has to be datetime.date."
-        )
+            "float, difficulty_id has to be an integer and date has to be datetime.date.")
 
 
 def insert_into_players(player_id, game_id, state):


### PR DESCRIPTION
Multiplayer will be an own game mode in terms of highscore. This is backed by the fact that configuration is different for multiplayer than singleplayer. In the db this is reflected in an own identifier for the multiplayer mode in the difficulty_id column on Scores. Added DifficultyId enum to utilities to have this under control.

Some of the code for high score fetching from db is very similar to singleplayer backend and this highlights the need to refactor the whole architecture, but this is a bigger scope than for the last 3 weeks of the summer project.

New websocket endpoints:
- postScore:
  - Every multiplayer game now also posts scores to db with the Multiplayer DifficultyId 4.
- viewHighscore
  - Essentially the same as in singleplayer backend