### PR TITLE
Sp24 470 create endpoint sending three images of a specific label

### DIFF
--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -204,7 +204,6 @@ def get_example_drawings(json_data):
     number_of_images = data["number_of_images"]
     label = data["label"]
     example_drawings = storage.get_n_random_images_from_label(number_of_images, label)
-    print(example_drawings)
     emit("getExampleDrawings", json.dumps(example_drawings), room=game_id)
 
 

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -194,6 +194,19 @@ def view_high_score(json_data):
 
     emit("viewHighScore", json.dumps(data), room=game_id)
 
+@socketio.on("getExampleDrawings")
+def get_example_drawings(json_data):
+    """
+        Get example drawings from the database
+    """
+    data = json.loads(json_data)
+    game_id = data["game_id"]
+    number_of_images = data["number_of_images"]
+    label = data["label"]
+    example_drawings = storage.get_n_random_images_from_label(number_of_images, label)
+    print(example_drawings)
+    emit("getExampleDrawings", json.dumps(example_drawings), room=game_id)
+
 
 @socketio.on("classify")
 def handle_classify(data, image, correct_label=None):

--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -194,6 +194,7 @@ def view_high_score(json_data):
 
     emit("viewHighScore", json.dumps(data), room=game_id)
 
+
 @socketio.on("getExampleDrawings")
 def get_example_drawings(json_data):
     """
@@ -203,7 +204,8 @@ def get_example_drawings(json_data):
     game_id = data["game_id"]
     number_of_images = data["number_of_images"]
     label = data["label"]
-    example_drawings = storage.get_n_random_images_from_label(number_of_images, label)
+    example_drawings = storage.get_n_random_images_from_label(
+        number_of_images, label)
     emit("getExampleDrawings", json.dumps(example_drawings), room=game_id)
 
 

--- a/src/webapp/storage.py
+++ b/src/webapp/storage.py
@@ -142,4 +142,3 @@ def image_to_data_url(image_data, content_type):
     """
     base64_image = base64.b64encode(image_data).decode('utf-8')
     return f"data:{content_type};base64,{base64_image}"
-

--- a/src/webapp/storage.py
+++ b/src/webapp/storage.py
@@ -12,6 +12,8 @@ from azure.storage.blob import BlobClient
 from azure.storage.blob import BlobServiceClient
 from utilities.keys import Keys
 from utilities import setup
+import random
+import base64
 
 
 def save_image(image, label, certainty):
@@ -96,11 +98,10 @@ def image_count():
     return container_client.get_container_properties().metadata["image_count"]
 
 
-def blob_connection():
+def blob_connection(container_name=setup.CONTAINER_NAME_NEW):
     """
         Helper method for connection to blob service.
     """
-    container_name = setup.CONTAINER_NAME_NEW
     connect_str = Keys.get("BLOB_CONNECTION_STRING")
     try:
         # Instantiate a BlobServiceClient using a connection string
@@ -115,3 +116,30 @@ def blob_connection():
         raise Exception("Could not connect to blob client: " + str(e))
 
     return container_client
+
+
+def get_n_random_images_from_label(n, label):
+    """
+        Returns n random images from the blob storage container with the given label.
+    """
+    container_client = blob_connection(setup.CONTAINER_NAME_ORIGINAL)
+    blob_prefix = f"{label}/"
+    blobs = list(container_client.list_blobs(name_starts_with=blob_prefix))
+    selected_blobs = random.sample(blobs, min(n, len(blobs)))
+    images = []
+    for blob in selected_blobs:
+        blob_client = container_client.get_blob_client(blob)
+        image_data = blob_client.download_blob().readall()
+        decoded_image = image_to_data_url(
+            image_data, blob.content_settings.content_type)
+        images.append(decoded_image)
+    return images
+
+
+def image_to_data_url(image_data, content_type):
+    """
+        Converts image data to a data URL.
+    """
+    base64_image = base64.b64encode(image_data).decode('utf-8')
+    return f"data:{content_type};base64,{base64_image}"
+


### PR DESCRIPTION
Identical functionality to the singleplayer backend to get a set of random drawings for a label, except that its a websocket.

- Once again: loads all images from blob storage. We should probably make it a point to find out if this is expensive
- Transforms it to data URLs so its easy to implement in the frontend framework