### PR TITLE
Add seperate endpoints for players

### DIFF
--- a/src/webapp/api.py
+++ b/src/webapp/api.py
@@ -196,7 +196,7 @@ def view_high_score(json_data):
 
 
 @socketio.on("getExampleDrawings")
-def get_example_drawings(json_data):
+def get_example_drawings(json_data, emitEndpoint="getExampleDrawings"):
     """
         Get example drawings from the database
     """
@@ -213,8 +213,15 @@ def get_example_drawings(json_data):
         label, number_of_images)
     example_drawings = storage.get_images_from_relative_url(
         example_drawing_urls)
-    emit("getExampleDrawings", json.dumps(example_drawings), room=game_id)
+    emit(emitEndpoint, json.dumps(example_drawings), room=game_id)
 
+@socketio.on("getExampleDrawingsP1")
+def get_example_drawings_player_1(json_data):
+    get_example_drawings(json_data, emitEndpoint="getExampleDrawingsP1")
+
+@socketio.on("getExampleDrawingsP2")
+def get_example_drawings_player_2(json_data):
+    get_example_drawings(json_data, emitEndpoint="getExampleDrawingsP2")
 
 @socketio.on("classify")
 def handle_classify(data, image, correct_label=None):


### PR DESCRIPTION
# Changes :gem:
_Had issues that the output of the previous endpoint was overwritten when both clients sent a request through the same channel at the same time. Fixed this by making it so that each socket calls its own endpoint based on its player number (logic in frontend)_